### PR TITLE
Fix some typing issues that crash things on julia 0.3.6

### DIFF
--- a/src/Autoreload.jl
+++ b/src/Autoreload.jl
@@ -153,7 +153,7 @@ function areload(command= :force; kwargs...)
     dependencies = get_dependency_graph()
     file_order = topological_sort(dependencies)
     should_reload = [filename=>false for filename in file_order]
-    marked_for_mtime_update = []
+    marked_for_mtime_update = String[]
     for (i, file) in enumerate(file_order)
         file_time = files[file].mtime
         if reload_mtime(file) > file_time

--- a/src/smart_types.jl
+++ b/src/smart_types.jl
@@ -212,7 +212,7 @@ end
 
 function extract_modules(e_block)
     modules = Dict{Symbol,Any}()
-    in_main = []
+    in_main = Any[]
     info_debug("beginning module extraction")
     for e in e_block.args
         # isa(e, Expr) || continue


### PR DESCRIPTION
This should fix #21. I can't test things on julia 0.4, so someone should make sure this doesn't break things on 0.4...