### PR TITLE
Switch deprecated require to include

### DIFF
--- a/src/Autoreload.jl
+++ b/src/Autoreload.jl
@@ -80,7 +80,7 @@ function arequire(filename=""; command= :on, depends_on=UTF8String[])
             push!(files[filename].deps, d)
         end
         if files[filename].should_reload
-            require(find_file(filename))
+            include(find_file(filename))
         end
     elseif command == :off
         if haskey(files, filename)

--- a/src/files.jl
+++ b/src/files.jl
@@ -8,7 +8,7 @@ function find_in_path(name::AbstractString; constants::Bool=true)
         name = string(base,".jl")
         isfile(name) && return abspath(name)
     end
-    for prefix in [Pkg.dir(), LOAD_PATH]
+    for prefix in [Pkg.dir(); LOAD_PATH]
         path = joinpath(prefix, name)
         if constants
             file_name = name


### PR DESCRIPTION
Hello @malmaud ,

`require(::AbstractString)` has been deprecated for a while now in both `v0.4` and `v0.5`. From what I can tell, switching to `include` doesn't change the package behavior at all. Is there some subtle difference that might break functionality?

Thanks,
Josh