### PR TITLE
compatible with Julia v0.5

### DIFF
--- a/src/Autoreload.jl
+++ b/src/Autoreload.jl
@@ -43,7 +43,7 @@ function remove_file(filename)
     pop!(files, filename)
 end
 
-function arequire(filename=""; command= :on, depends_on=UTF8String[])
+function arequire(filename=""; command= :on, depends_on=String[])
     if isempty(filename)
         return collect(keys(files))
     end
@@ -61,7 +61,7 @@ function arequire(filename=""; command= :on, depends_on=UTF8String[])
         else
             should_reload = was_reloading
         end
-        files[filename] = AFile(should_reload, reload_mtime(filename), UTF8String[])
+        files[filename] = AFile(should_reload, reload_mtime(filename), String[])
         parsed_file = parse_file(filename)
         auto_depends = extract_deps(parsed_file)
         auto_depends = [_.name for _ in auto_depends] #todo respect reload flag
@@ -155,8 +155,8 @@ function areload(command= :force; kwargs...)
     end
     dependencies = get_dependency_graph()
     file_order = topological_sort(dependencies)
-    should_reload = [filename=>false for filename in file_order]
-    marked_for_mtime_update = UTF8String[]
+    should_reload = Dict(filename=>false for filename in file_order)
+    marked_for_mtime_update = String[]
     for (i, file) in enumerate(file_order)
         file_time = files[file].mtime
         if reload_mtime(file) > file_time

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,15 +1,15 @@
 type AFile
     should_reload::Bool
     mtime::Float64
-    deps::Vector{UTF8String}
+    deps::Vector{String}
 end
 
 type Dep
     should_reload::Bool
-    name::UTF8String
+    name::String
 end
 suppress_warnings = false
-const files = Dict{UTF8String,AFile}()
+const files = Dict{String,AFile}()
 const options = @compat Dict{Symbol,Any}(:constants=>false, :strip_types=>true, :smart_types=>true, :verbose_level=>:warn, :state=>:on)
 # verbose_level = :warn
 # state = :on

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -43,7 +43,7 @@ end
 
 
 function get_dependency_graph()
-    deps = [filename=>afile.deps for (filename, afile) in files]
+    deps = Dict(filename=>afile.deps for (filename, afile) in files)
     return deps
 end
 

--- a/src/files.jl
+++ b/src/files.jl
@@ -60,7 +60,7 @@ end
 function parse_file(filename; kwargs...)
     path = find_file(filename; kwargs...)
     handle = open(path)
-    source = string("begin\n", readall(handle), "\n end")
+    source = string("begin\n", readstring(handle), "\n end")
     close(handle)
     parsed = parse(source)
     return parsed

--- a/src/smart_types.jl
+++ b/src/smart_types.jl
@@ -62,14 +62,14 @@ function reload_module(name, e)
     local m_tmp
     info_debug("reloading module $name")
     while true
-        m_tmp = symbol("_m_tmp_$(rand(1:100000))") #todo must be better way to do this
+        m_tmp = Symbol("_m_tmp_$(rand(1:100000))") #todo must be better way to do this
         if !(m_tmp in names(Main, true))
             break
         end
     end
     m = nothing
     if name in names(Main, true)
-        m = Main.(name)
+        m = getfield(Main,name)
         if isa(m, Module)
             @type_strip
             # if options[:strip_types]
@@ -300,7 +300,7 @@ function alter_type(x, T::DataType, var_name="")
         x_new = T()
         for field in fields
             if field in old_fields
-                x_new.(field) = x.(field)
+                set_field!(x_new,field,x.(field))
             end
         end
     catch


### PR DESCRIPTION
I made a few minor changes to make Autoreload work with Julia v0.5 and get rid of warnings. I can't say I've super extensively tested everything, but `runtests.jl` seems fine as does all the basic `@ausing` usage that I had in my own workflow. 

However, on v0.5 you get method redefinition warning which were not present on v0.4.X, so I think that still needs to be fixed, although I don't know enough about the package to know how to. 

Eg:

```
$ julia runtests.jl 
WARNING: Method definition (::Type{M.MyType})(Int64) in module M at /home/marius/.julia/v0.5/Autoreload/test/M.jl:3 overwritten at none:4.
WARNING: Method definition (::Type{M.MyType})(Any) in module M at /home/marius/.julia/v0.5/Autoreload/test/M.jl:3 overwritten at none:4.
WARNING: Method definition f(M.MyType) in module M at /home/marius/.julia/v0.5/Autoreload/test/M.jl:6 overwritten at none:7.
```
